### PR TITLE
Linux fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libraries/linalg"]
 	path = libraries/linalg
-	url = https://github.com/sgorsten/linalg.git
+	url = https://github.com/Syuff/Simple-OpenVR-Bridge-Driver/tree/linux
 [submodule "libraries/openvr"]
 	path = libraries/openvr
 	url = https://github.com/ValveSoftware/openvr.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,5 @@
 [submodule "libraries/openvr"]
 	path = libraries/openvr
 	url = https://github.com/ValveSoftware/openvr.git
+[submodule "./libraries/linalg/"]
+	url = https://github.com/sgorsten/linalg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries("${EXAMPLE_PROJECT}" PUBLIC "${OPENVR_LIB}")
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/driver_files/src" PREFIX "Header Files" FILES ${HEADERS})
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/driver_files/src" PREFIX "Source Files" FILES ${SOURCES})
 set_property(TARGET "${EXAMPLE_PROJECT}" PROPERTY CXX_STANDARD 17)
+set_property(TARGET "${EXAMPLE_PROJECT}" PROPERTY PREFIX "")
 
 # Copy driver assets to output folder
 add_custom_command(


### PR DESCRIPTION
Fixed linalg header for linux as hash was not included (currently on fork).

Removed driver binary name prefix for linux (steamvr does not like prefix).