### PR TITLE
Some misc fixes

### DIFF
--- a/driver_files/src/Driver/IVRDevice.hpp
+++ b/driver_files/src/Driver/IVRDevice.hpp
@@ -50,14 +50,6 @@ namespace ExampleDriver {
             return out_pose;
         }
 
-        // Inherited via ITrackedDeviceServerDriver
-        virtual vr::EVRInitError Activate(uint32_t unObjectId) = 0;
-        virtual void Deactivate() = 0;
-        virtual void EnterStandby() = 0;
-        virtual void* GetComponent(const char* pchComponentNameAndVersion) = 0;
-        virtual void DebugRequest(const char* pchRequest, char* pchResponseBuffer, uint32_t unResponseBufferSize) = 0;
-        virtual vr::DriverPose_t GetPose() = 0;
-
         ~IVRDevice() = default;
     };
 };

--- a/driver_files/src/Driver/IVRDriver.hpp
+++ b/driver_files/src/Driver/IVRDriver.hpp
@@ -9,7 +9,7 @@ namespace ExampleDriver {
 
     typedef std::variant<std::monostate, std::string, int, float, bool> SettingsValue;
 
-    class IVRDriver : protected vr::IServerTrackedDeviceProvider {
+    class IVRDriver : public vr::IServerTrackedDeviceProvider {
     public:
 
         /// <summary>

--- a/driver_files/src/Driver/Key.cpp
+++ b/driver_files/src/Driver/Key.cpp
@@ -31,8 +31,8 @@ namespace Key {
         }
 #else
         (void)key;
-        return false;
 #endif
+        return false;
     }
 
 }; // namespace Key

--- a/driver_files/src/Driver/TrackerDevice.cpp
+++ b/driver_files/src/Driver/TrackerDevice.cpp
@@ -19,8 +19,6 @@ ExampleDriver::TrackerDevice::TrackerDevice(std::string serial, std::string role
     serial_(serial),
     role_(role)
 {
-    this->last_pose_ = MakeDefaultPose();
-    this->isSetup = false;
 }
 
 std::string ExampleDriver::TrackerDevice::GetSerial()
@@ -51,28 +49,6 @@ void ExampleDriver::TrackerDevice::Update()
 {
     if (this->device_index_ == vr::k_unTrackedDeviceIndexInvalid)
         return;
-
-    // Check if this device was asked to be identified
-    auto events = GetDriver()->GetOpenVREvents();
-    for (auto event : events) {
-        // Note here, event.trackedDeviceIndex does not necissarily equal this->device_index_, not sure why, but the component handle will match so we can just use that instead
-        //if (event.trackedDeviceIndex == this->device_index_) {
-        if (event.eventType == vr::EVREventType::VREvent_Input_HapticVibration) {
-            if (event.data.hapticVibration.componentHandle == this->haptic_component_) {
-                this->did_vibrate_ = true;
-            }
-        }
-        //}
-    }
-
-    // Check if we need to keep vibrating
-    if (this->did_vibrate_) {
-        this->vibrate_anim_state_ += (GetDriver()->GetLastFrameTime().count() / 1000.f);
-        if (this->vibrate_anim_state_ > 1.0f) {
-            this->did_vibrate_ = false;
-            this->vibrate_anim_state_ = 0.0f;
-        }
-    }
 
     // Setup pose for this frame
     auto pose = this->last_pose_;

--- a/driver_files/src/Driver/TrackerDevice.cpp
+++ b/driver_files/src/Driver/TrackerDevice.cpp
@@ -47,7 +47,7 @@ void ExampleDriver::TrackerDevice::reinit(int msaved, double mtime, double msmoo
     max_time = mtime;
     smoothing = msmooth;
 
-    //Log("Settings changed! " + std::to_string(msaved) + " " + std::to_string(mtime));
+    Log("Settings changed! " + std::to_string(msaved) + ' ' + std::to_string(mtime) + ' ' + std::to_string(msmooth));
 }
 
 void ExampleDriver::TrackerDevice::Update()
@@ -77,6 +77,7 @@ void ExampleDriver::TrackerDevice::Update()
 
     const bool pose_nan = std::any_of(next_pose.begin(), next_pose.end(), [](double d) { return std::isnan(d); });
     if (pose_nan) {
+        Log("Not submitting pose! NaNs were seen");
         return;
     }
 
@@ -265,11 +266,14 @@ void ExampleDriver::TrackerDevice::save_current_pose(double a, double b, double 
         return;
     }
 
-    if (time > max_time)
+    if (time > max_time) {
+        Log("Dropped a pose! It was too old");
         return;
+    }
 
     auto first_outdated = std::find_if(prev_positions.begin(), prev_positions.end(), [time](const PrevPose& prev_pose) { return prev_pose.time < 0 || prev_pose.time > time; });
     if (first_outdated == prev_positions.end()) {
+        Log("Dropped a pose! All previous poses are newer");
         return;
     }
 

--- a/driver_files/src/Driver/TrackerDevice.hpp
+++ b/driver_files/src/Driver/TrackerDevice.hpp
@@ -57,7 +57,6 @@ namespace ExampleDriver {
             PoseInfo pose;
         };
 
-        int max_saved = 10;
         std::vector<PrevPose> prev_positions; // koliko cajta nazaj se je naredl, torej min-->max
         std::chrono::system_clock::time_point last_update;
         double max_time = 1;

--- a/driver_files/src/Driver/TrackerDevice.hpp
+++ b/driver_files/src/Driver/TrackerDevice.hpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <iostream>
 #include <string>
+#include <mutex>
 
 namespace ExampleDriver {
     class TrackerDevice : public IVRDevice {
@@ -57,6 +58,7 @@ namespace ExampleDriver {
             PoseInfo pose;
         };
 
+        mutable std::mutex pose_mutex;
         std::vector<PrevPose> prev_positions; // koliko cajta nazaj se je naredl, torej min-->max
         std::chrono::system_clock::time_point last_update;
         double max_time = 1;

--- a/driver_files/src/Driver/TrackerDevice.hpp
+++ b/driver_files/src/Driver/TrackerDevice.hpp
@@ -43,19 +43,10 @@ namespace ExampleDriver {
         vr::TrackedDeviceIndex_t device_index_ = vr::k_unTrackedDeviceIndexInvalid;
         std::string serial_;
         std::string role_;
-        bool isSetup;
 
         std::chrono::milliseconds _pose_timestamp;
 
         vr::DriverPose_t last_pose_ = IVRDevice::MakeDefaultPose();
-
-        bool did_vibrate_ = false;
-        float vibrate_anim_state_ = 0.f;
-
-        vr::VRInputComponentHandle_t haptic_component_ = 0;
-
-        vr::VRInputComponentHandle_t system_click_component_ = 0;
-        vr::VRInputComponentHandle_t system_touch_component_ = 0;
 
         int max_saved = 10;
         std::vector<std::vector<double>> prev_positions; // prev_positions[:][0] je time since now (koliko cajta nazaj se je naredl, torej min-->max)

--- a/driver_files/src/Driver/TrackerDevice.hpp
+++ b/driver_files/src/Driver/TrackerDevice.hpp
@@ -20,6 +20,8 @@ namespace ExampleDriver {
             // [position[x, y, z], rotation[w, x, y, z]]
             using PoseInfo = std::array<double, 7>;
 
+            using Seconds = std::chrono::duration<double>;
+
             TrackerDevice(std::string serial, std::string role);
             ~TrackerDevice() = default;
 
@@ -38,15 +40,15 @@ namespace ExampleDriver {
             virtual vr::DriverPose_t GetPose() override;
 
             void reinit(int msaved, double mtime, double msmooth);
-            void save_current_pose(double a, double b, double c, double qw, double qx, double qy, double qz, double time);
-            int get_next_pose(double req_time, PoseInfo& pred) const;
+            void save_current_pose(double a, double b, double c, double qw, double qx, double qy, double qz, Seconds time_offset);
+            int get_next_pose(Seconds time_offset, PoseInfo& pred) const;
 
     private:
         vr::TrackedDeviceIndex_t device_index_ = vr::k_unTrackedDeviceIndexInvalid;
         std::string serial_;
         std::string role_;
 
-        std::chrono::milliseconds _pose_timestamp;
+        std::chrono::system_clock::time_point _pose_timestamp;
 
         vr::DriverPose_t last_pose_ = IVRDevice::MakeDefaultPose();
 
@@ -57,7 +59,7 @@ namespace ExampleDriver {
 
         int max_saved = 10;
         std::vector<PrevPose> prev_positions; // koliko cajta nazaj se je naredl, torej min-->max
-        double last_update = 0;
+        std::chrono::system_clock::time_point last_update;
         double max_time = 1;
         double smoothing = 0;
 

--- a/driver_files/src/Driver/TrackerDevice.hpp
+++ b/driver_files/src/Driver/TrackerDevice.hpp
@@ -42,7 +42,7 @@ namespace ExampleDriver {
 
             void reinit(int msaved, double mtime, double msmooth);
             void save_current_pose(double a, double b, double c, double qw, double qx, double qy, double qz, Seconds time_offset);
-            int get_next_pose(Seconds time_offset, PoseInfo& pred) const;
+            int get_next_pose(Seconds time_offset, PoseInfo& next_pose, PoseInfo* pose_rate = nullptr) const;
 
     private:
         vr::TrackedDeviceIndex_t device_index_ = vr::k_unTrackedDeviceIndexInvalid;

--- a/driver_files/src/Driver/VRDriver.cpp
+++ b/driver_files/src/Driver/VRDriver.cpp
@@ -115,7 +115,7 @@ void ExampleDriver::VRDriver::PipeThread()
                 }
                 else if (word == "addstation")
                 {
-                    auto addstation = std::make_shared<TrackingReferenceDevice>("AprilCamera" + std::to_string(this->devices_.size()));
+                    auto addstation = std::make_shared<TrackingReferenceDevice>("AprilCamera" + std::to_string(this->stations_.size()));
                     this->AddDevice(addstation);
                     this->stations_.push_back(addstation);
                     s = s + " added";
@@ -173,7 +173,7 @@ void ExampleDriver::VRDriver::PipeThread()
                     double a, b, c, time, smoothing;
                     iss >> idx; iss >> a; iss >> b; iss >> c; iss >> time; iss >> smoothing;
 
-                    if (idx < this->devices_.size())
+                    if (idx < this->trackers_.size())
                     {
                         this->trackers_[idx]->UpdatePos(a, b, c, time, smoothing);
                         this->trackers_[idx]->Update();
@@ -191,7 +191,7 @@ void ExampleDriver::VRDriver::PipeThread()
                     double qw, qx, qy, qz, time, smoothing;
                     iss >> qw; iss >> qx; iss >> qy; iss >> qz; iss >> time; iss >> smoothing;
 
-                    if (idx < this->devices_.size())
+                    if (idx < this->trackers_.size())
                     {
                         this->trackers_[idx]->UpdateRot(qw, qx, qy, qz, time, smoothing);
                         this->trackers_[idx]->Update();
@@ -230,7 +230,7 @@ void ExampleDriver::VRDriver::PipeThread()
                     iss >> idx;
                     iss >> time_offset;
 
-                    if (idx < this->devices_.size())
+                    if (idx < this->trackers_.size())
                     {
                         s = s + " trackerpose " + std::to_string(idx);
 
@@ -315,7 +315,7 @@ void ExampleDriver::VRDriver::RunFrame()
     this->frame_timing_avg_ = this->frame_timing_avg_ * 0.9 + ((double)this->frame_timing_.count()) * 0.1;
     //MessageBox(NULL, std::to_string(((double)this->frame_timing_.count()) * 0.1).c_str(), "Example Driver", MB_OK);
 
-    for (auto& device : this->trackers_)
+    for (auto& device : this->devices_)
         device->Update();
 
 }

--- a/driver_files/src/Driver/VRDriver.cpp
+++ b/driver_files/src/Driver/VRDriver.cpp
@@ -156,7 +156,7 @@ void ExampleDriver::VRDriver::PipeThread()
                     {
                         if(time < 0)
                             time = -time;
-                        this->trackers_[idx]->save_current_pose(a, b, c, qw, qx, qy, qz, time);
+                        this->trackers_[idx]->save_current_pose(a, b, c, qw, qx, qy, qz, TrackerDevice::Seconds(time));
                         //this->trackers_[idx]->UpdatePos(a, b, c, time, 1-smoothing);
                         //this->trackers_[idx]->UpdateRot(qw, qx, qy, qz, time, 1-smoothing);
 
@@ -238,7 +238,7 @@ void ExampleDriver::VRDriver::PipeThread()
                         s = s + " trackerpose " + std::to_string(idx);
 
                         TrackerDevice::PoseInfo pose;
-                        int statuscode = this->trackers_[idx]->get_next_pose(time_offset, pose);
+                        int statuscode = this->trackers_[idx]->get_next_pose(TrackerDevice::Seconds(time_offset), pose);
 
                         s = s + " " + std::to_string(pose[0]) +
                             " " + std::to_string(pose[1]) +

--- a/driver_files/src/Driver/VRDriver.cpp
+++ b/driver_files/src/Driver/VRDriver.cpp
@@ -237,7 +237,7 @@ void ExampleDriver::VRDriver::PipeThread()
                     {
                         s = s + " trackerpose " + std::to_string(idx);
 
-                        double pose[7];
+                        TrackerDevice::PoseInfo pose;
                         int statuscode = this->trackers_[idx]->get_next_pose(time_offset, pose);
 
                         s = s + " " + std::to_string(pose[0]) +

--- a/driver_files/src/Driver/VRDriver.cpp
+++ b/driver_files/src/Driver/VRDriver.cpp
@@ -50,11 +50,8 @@ void ExampleDriver::VRDriver::PipeThread()
         //we go and read it into our buffer
         if (ipcConnection.recv(buffer, sizeof(buffer)))
         {
-            //MessageBoxA(NULL, "connected2", "Example Driver", MB_OK);
             //convert our buffer to string
-
-            //MessageBoxA(NULL, buffer, "Example Driver", MB_OK);
-
+            buffer[sizeof(buffer) - 1] = '\0';
             std::string rec = buffer;
 
             //Log("Received message: " + rec);

--- a/driver_files/src/Native/DriverFactory.cpp
+++ b/driver_files/src/Native/DriverFactory.cpp
@@ -13,7 +13,7 @@ void* HmdDriverFactory(const char* interface_name, int* return_code) {
 			driver = std::make_shared<ExampleDriver::VRDriver>();
 		}
 		// We always have at least 1 ref to the shared ptr in "driver" so passing out raw pointer is ok
-		return driver.get();
+		return static_cast<vr::IServerTrackedDeviceProvider*>(driver.get());
 	}
 
 	if (return_code)

--- a/libraries/ipc/Ipc.cpp
+++ b/libraries/ipc/Ipc.cpp
@@ -20,7 +20,18 @@ namespace Ipc {
 
     Connection::~Connection()
     {
-        DisconnectNamedPipe(inPipe);
+        if (inPipe != INVALID_HANDLE_VALUE) {
+            DisconnectNamedPipe(inPipe);
+        }
+    }
+
+    Connection::Connection(Connection &&other) noexcept : inPipe(INVALID_HANDLE_VALUE) {
+        operator=(std::move(other));
+    }
+
+    Connection& Connection::operator=(Connection &&other) noexcept {
+        std::swap(inPipe, other.inPipe);
+        return *this;
     }
 
     bool Connection::send(const char *buffer, size_t length)
@@ -167,7 +178,18 @@ namespace Ipc {
 
     Connection::~Connection()
     {
-        ::close(connfd);
+        if (connfd != -1) {
+            ::close(connfd);
+        }
+    }
+
+    Connection::Connection(Connection&& other) noexcept : connfd(-1) {
+        operator=(std::move(other));
+    }
+
+    Connection& Connection::operator=(Connection&& other) noexcept {
+        std::swap(connfd, other.connfd);
+        return *this;
     }
 
     bool Connection::send(const char *buf, size_t len)
@@ -252,6 +274,8 @@ namespace Ipc {
 
     Connection::Connection() { }
     Connection::~Connection() { }
+    Connection::Connection(Connection&&) noexcept = default;
+    Connection& Connection::operator=(Connection&&) noexcept = default;
     bool Connection::send(const char *buf, size_t len)
     {
         return false;

--- a/libraries/ipc/Ipc.hpp
+++ b/libraries/ipc/Ipc.hpp
@@ -18,8 +18,8 @@ namespace Ipc {
             Connection& operator=(Connection const &) = delete;
 
             // Moving is allowed
-            Connection(Connection &&) = default;
-            Connection& operator=(Connection &&) = default;
+            Connection(Connection &&) noexcept;
+            Connection& operator=(Connection &&) noexcept;
 
             bool send(const char *buffer, size_t length);
             bool recv(char *buffer, size_t length);


### PR DESCRIPTION
I've split out the new prediction model stuff since while I think it's working well, I need more time to test it proper. This branch is now just the misc changes I'd made and spotted while taking a peek at the code.

Most notably is 4fb40c69dd928993d188264fe4af0094bb46c34f which should stop `NaN`s from appearing whenever the variance of the position/rotation is 0, ie no movement. This would have caused `rxy` to be `inf` due to a divide by 0, and then `b` would become `NaN` due to `inf * 0 == NaN` (since `sv` would also be `0`).

551095f703ad6b29ed27ec2c75622c68cee3dff8 may also be unnecessary since we update the position in the `Update()` loop, but the documentation does state that it's unreliable and not necessarily every frame so if we do miss a frame it shouldn't stutter.

~~A bigger issue I'm seeing though is that the server is only getting messages every 0.06s despite inference timestamps reporting 0.02s on the python side. Adding `OVERLAPPED` support to the named pipe so that a reader is available immediately after the client disconnects made the errors about failing to send go away (in a simulated test case) but it's still only connecting every 0.06s in that test case. Judging by the code a log message about inference time doesn't necessarily imply that there's a new pose so information in the log about that could be useful. Note that lowering the quality of the model or prediction threshold can drop the inference time to 0.01s but the connection still only happens once every 0.06s which confuses me even more.~~ Edit: ended up being a configuration error: lowering the exposure reduced motion blur and resulted in more frequent updates on the server. Another case of "a few hours of trial and error can save you several minutes of looking at the README."

<details>
<summary>Old description</summary>

This is really an amalgamation of 2 PRs, one from when I first poked around with the mediapipe tracking repo a while ago and fixed some issues I noted, and another from the past few days where I was looking into making the tracking more accurate/responsive. In doing so I've also simplified the code in the existing prediction model which has removed avoid what I assume was a division-by-zero check. You can check that it's the same mathematically by expanding the stddev formula and using the observation that `sum(x_n) = avg_x * N`, or just eyeballing the result with dimensional analysis.

Conceptually, the linear regression model is looking at the "average" velocity over the window of data and trying to predict the next sample from that, which means that if the window isn't close to being odd-symmetric (linear, cubic, etc...) then the prediction can go in the wrong direction. A higher order polynomial approximation might work here, but I reasoned that the latency would be too high and extrapolating that far would send the trackers flying off.

Instead I thought about trying to estimate the instantaneous velocity at the end of the window. To do this I look at all of the snapshot velocities in the window and perform a weighted average on them. Note that the weights I'm using are mostly arbitrary and there might be a better weighting (exponential? logarithmic? option 3?) but this works pretty well for now.

I've included the script that I used to test the new model and convince myself that it might work better. It sets up some time points and introduces random delays between them, then it samples a given curve at those time points plus/minus a random measurement error. It then feeds a window of that data into a predictor and sees how accurate it was to the actual "next" value of the given curve. It should be trivial to extend the script for new prediction methods and movement types too to test their predictive power. For example, it also includes a naive velocity based approach that only looks at the last 2 positions, and as expected it performs worse overall than either the linear regression or the weighted velocity models. Note that the linear regression and the weighted velocity models score very similarly with no clear winner, which was all the convincing I needed to try it out :P

I still need to record an example of it in action, but with a window size of 1 second and 0 additional smoothing there's a big difference in the responsiveness to sudden limb movements and it no longer overpredicts and bounces back when you stop moving (put your hand on your knee and lift your leg quickly). I haven't tested non-0 smoothing yet, but I expect it'll continue to act as a low-pass filter removing the slight jitter in the new model, and I'm using mediapipe only so no testing with the actual AprilTags.

Note that the latest commit is just for testing and I'll drop it at some point. Also I've only just seen #12, so hopefully I'm not treading on any toes!

</details>